### PR TITLE
Apply fontStyle setting

### DIFF
--- a/src/drawpyo/diagram/base_diagram.py
+++ b/src/drawpyo/diagram/base_diagram.py
@@ -243,7 +243,7 @@ class DiagramBase(XMLBase):
 
         # Add style objects
         if hasattr(self, "text_format") and self.text_format is not None:
-            style_str = style_str + self.text_format.style
+            style_str = style_str + self.text_format.style + f"fontStyle={self.text_format.font_style};"
         return style_str
 
     def _add_and_set_style_attrib(self, attrib, value):


### PR DESCRIPTION
Hi! I found that font style property does exist while it's not applied to diagrams. If we run the code below 
```python
import os
from os import path
from drawpyo.diagram_types import TreeDiagram, NodeObject
from drawpyo.diagram.text_format import TextFormat


def main():
    text_format = TextFormat(bold=True, italic=True)
    filepath = path.join(os.getcwd(), "example.drawio")
    tree = TreeDiagram(
        file_path=path.dirname(filepath),
        file_name=path.basename(filepath),
        direction="down",
        link_style="orthogonal",
    )

    # Top object
    grinders = NodeObject(tree=tree, value="Appliances for Grinding Coffee",
                          base_style="rounded rectangle", text_format=text_format)

    # Main categories
    blade_grinders = NodeObject(tree=tree, value="Blade Grinders", parent=grinders)
    burr_grinders = NodeObject(tree=tree, value="Burr Grinders", parent=grinders)
    blunt_objects = NodeObject(tree=tree, value="Blunt Objects", parent=grinders)

    tree.auto_layout()
    tree.write()


if __name__ == '__main__':
    main()
```

it will result in the `Appliances for Grinding Coffee` text being both bold and italic as expected for the first node object for this PR's code and ignoring user settings in the current main branch/release one.

Even though I applied only minimum changes (just appending the font style string), I think it would fit more the current code style if we rename property
```python
    @property
    def font_style(self):
      ...
```

of the `drawpyo.diagram.text_format.TextFormat` class to the `fontStyle` instead of `font_style` and this new name append to the existing list `self._style_attributes`.

What do you think? Should I change the property name and use it in the `_style_attributes` attr?