### PR TITLE
Renamed .children and .parent objects of TreeDiagram to .tree_childre…

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,22 +96,22 @@ Create some NodeObjects:
 grinders = NodeObject(tree=tree, value="Appliances for Grinding Coffee", base_style="rounded rectangle")
 
 # Main categories
-blade_grinders = NodeObject(tree=tree, value="Blade Grinders", parent=grinders)
-burr_grinders = NodeObject(tree=tree, value="Burr Grinders", parent=grinders)
-blunt_objects = NodeObject(tree=tree, value="Blunt Objects", parent=grinders)
+blade_grinders = NodeObject(tree=tree, value="Blade Grinders", tree_parent=grinders)
+burr_grinders = NodeObject(tree=tree, value="Burr Grinders", tree_parent=grinders)
+blunt_objects = NodeObject(tree=tree, value="Blunt Objects", tree_parent=grinders)
 ```
 
 Note that the base_style was manually declared for the first object. But NodeObjects will default to "rounded rectangle" so it's not necessary for every one. Any NodeObject can be a parent, so you can keep adding objects down the tree:
 
 ```python
 # Other
-elec_blade = NodeObject(tree=tree, value="Electric Blade Grinder", parent=blade_grinders)
-mnp = NodeObject(tree=tree, value="Mortar and Pestle", parent=blunt_objects)
+elec_blade = NodeObject(tree=tree, value="Electric Blade Grinder", tree_parent=blade_grinders)
+mnp = NodeObject(tree=tree, value="Mortar and Pestle", tree_parent=blunt_objects)
 
 # Conical Burrs
-conical = NodeObject(tree=tree, value="Conical Burrs", parent=burr_grinders)
-elec_conical = NodeObject(tree=tree, value="Electric", parent=conical)
-manual_conical = NodeObject(tree=tree, value="Manual", parent=conical)
+conical = NodeObject(tree=tree, value="Conical Burrs", tree_parent=burr_grinders)
+elec_conical = NodeObject(tree=tree, value="Electric", tree_parent=conical)
+manual_conical = NodeObject(tree=tree, value="Manual", tree_parent=conical)
 ```
 
 > **Important Note:** TreeDiagrams do not currently support NodeObjects with multiple parents! It may not ever as this seriously complicates the auto layout process. However, you can add links between any two objects in the tree and render them in the diagram. They just may look ugly until you manually rearrange the diagram.

--- a/docs/diagram_types/tree_diagrams.md
+++ b/docs/diagram_types/tree_diagrams.md
@@ -1,6 +1,6 @@
 # Tree Diagrams
 
-These very useful diagram types are why drawpyo was written initially! The TreeDiagram module allows the easy creation of heirarchical directed trees, managing the parent and children relationships, then providing a convenient auto layout function.
+These very useful diagram types are why drawpyo was written initially! The TreeDiagram module allows the easy creation of heirarchical directed trees, managing the tree parent and children relationships, then providing a convenient auto layout function.
 
 ## Create a Tree
 
@@ -36,25 +36,25 @@ from drawpyo.diagram_types import NodeObject
 grinders = NodeObject(tree=tree, value="Appliances for Grinding Coffee", base_style="rounded rectangle")
 
 # Main categories
-blade_grinders = NodeObject(tree=tree, value="Blade Grinders", parent=grinders)
-burr_grinders = NodeObject(tree=tree, value="Burr Grinders", parent=grinders)
-blunt_objects = NodeObject(tree=tree, value="Blunt Objects", parent=grinders)
+blade_grinders = NodeObject(tree=tree, value="Blade Grinders", tree_parent=grinders)
+burr_grinders = NodeObject(tree=tree, value="Burr Grinders", tree_parent=grinders)
+blunt_objects = NodeObject(tree=tree, value="Blunt Objects", tree_parent=grinders)
 ```
 
-Note that the base_style was manually declared for the first object. But NodeObjects will default to "rounded rectangle" so it's not necessary for every one. Any NodeObject can be a parent, so you can keep adding objects down the tree:
+Note that the base_style was manually declared for the first object. But NodeObjects will default to "rounded rectangle" so it's not necessary for every one. Any NodeObject can be a tree parent, so you can keep adding objects down the tree:
 
 ```python
 # Other
-elec_blade = NodeObject(tree=tree, value="Electric Blade Grinder", parent=blade_grinders)
-mnp = NodeObject(tree=tree, value="Mortar and Pestle", parent=blunt_objects)
+elec_blade = NodeObject(tree=tree, value="Electric Blade Grinder", tree_parent=blade_grinders)
+mnp = NodeObject(tree=tree, value="Mortar and Pestle", tree_parent=blunt_objects)
 
 # Conical Burrs
-conical = NodeObject(tree=tree, value="Conical Burrs", parent=burr_grinders)
-elec_conical = NodeObject(tree=tree, value="Electric", parent=conical)
-manual_conical = NodeObject(tree=tree, value="Manual", parent=conical)
+conical = NodeObject(tree=tree, value="Conical Burrs", tree_parent=burr_grinders)
+elec_conical = NodeObject(tree=tree, value="Electric", tree_parent=conical)
+manual_conical = NodeObject(tree=tree, value="Manual", tree_parent=conical)
 ```
 
-> **Important Note:** TreeDiagrams do not currently support NodeObjects with multiple parents! It may not ever as this seriously complicates the auto layout process. However, you can add links between any two objects in the tree and render them in the diagram. They just may look ugly until you manually rearrange the diagram.
+> **Important Note:** TreeDiagrams do not currently support NodeObjects with multiple tree parents! It may not ever as this seriously complicates the auto layout process. However, you can add links between any two objects in the tree and render them in the diagram. They just may look ugly until you manually rearrange the diagram.
 
 Finally, before writing the diagram you'll want to run the magic penultimate step: auto layout.
 

--- a/etc/development scripts/generate_tree_diagram.py
+++ b/etc/development scripts/generate_tree_diagram.py
@@ -14,36 +14,36 @@ grinders = NodeObject(
 )
 
 # Main categories
-blade_grinders = NodeObject(tree=tree, value="Blade Grinders", parent=grinders)
-burr_grinders = NodeObject(tree=tree, value="Burr Grinders", parent=grinders)
-blunt_objects = NodeObject(tree=tree, value="Blunt Objects", parent=grinders)
+blade_grinders = NodeObject(tree=tree, value="Blade Grinders", tree_parent=grinders)
+burr_grinders = NodeObject(tree=tree, value="Burr Grinders", tree_parent=grinders)
+blunt_objects = NodeObject(tree=tree, value="Blunt Objects", tree_parent=grinders)
 
 # Other
 elec_blade = NodeObject(
-    tree=tree, value="Electric Blade Grinder", parent=blade_grinders
+    tree=tree, value="Electric Blade Grinder", tree_parent=blade_grinders
 )
-mnp = NodeObject(tree=tree, value="Mortar and Pestle", parent=blunt_objects)
+mnp = NodeObject(tree=tree, value="Mortar and Pestle", tree_parent=blunt_objects)
 
 # Conical Burrs
-conical = NodeObject(tree=tree, value="Conical Burrs", parent=burr_grinders)
-elec_conical = NodeObject(tree=tree, value="Electric", parent=conical)
-manual_conical = NodeObject(tree=tree, value="Manual", parent=conical)
+conical = NodeObject(tree=tree, value="Conical Burrs", tree_parent=burr_grinders)
+elec_conical = NodeObject(tree=tree, value="Electric", tree_parent=conical)
+manual_conical = NodeObject(tree=tree, value="Manual", tree_parent=conical)
 
-HarioSkerton = NodeObject(tree=tree, value="Hario Skerton", parent=manual_conical)
-Comandante = NodeObject(tree=tree, value="Comandante", parent=manual_conical)
-JZpresso = NodeObject(tree=tree, value="ZJpresso JX-Pro", parent=manual_conical)
-weberHG2 = NodeObject(tree=tree, value="Weber HG-2", parent=manual_conical)
+HarioSkerton = NodeObject(tree=tree, value="Hario Skerton", tree_parent=manual_conical)
+Comandante = NodeObject(tree=tree, value="Comandante", tree_parent=manual_conical)
+JZpresso = NodeObject(tree=tree, value="ZJpresso JX-Pro", tree_parent=manual_conical)
+weberHG2 = NodeObject(tree=tree, value="Weber HG-2", tree_parent=manual_conical)
 
-BaratzaEnc = NodeObject(tree=tree, value="Baratza Encore", parent=elec_conical)
-Niche = NodeObject(tree=tree, value="Niche Zero", parent=elec_conical)
-WeberKey = NodeObject(tree=tree, value="Weber Key", parent=elec_conical)
+BaratzaEnc = NodeObject(tree=tree, value="Baratza Encore", tree_parent=elec_conical)
+Niche = NodeObject(tree=tree, value="Niche Zero", tree_parent=elec_conical)
+WeberKey = NodeObject(tree=tree, value="Weber Key", tree_parent=elec_conical)
 
 # Flat Burrs
-flat = NodeObject(tree=tree, value="Flat Burrs", parent=burr_grinders)
+flat = NodeObject(tree=tree, value="Flat Burrs", tree_parent=burr_grinders)
 
-DF64 = NodeObject(tree=tree, value="Turin DF64", parent=flat)
-FellowOde = NodeObject(tree=tree, value="Fellow Ode", parent=flat)
-LagomP64 = NodeObject(tree=tree, value="Lagom P64", parent=flat)
+DF64 = NodeObject(tree=tree, value="Turin DF64", tree_parent=flat)
+FellowOde = NodeObject(tree=tree, value="Fellow Ode", tree_parent=flat)
+LagomP64 = NodeObject(tree=tree, value="Lagom P64", tree_parent=flat)
 
 grp = tree.auto_layout()
 tree.write()

--- a/src/drawpyo/diagram_types/tree.py
+++ b/src/drawpyo/diagram_types/tree.py
@@ -14,13 +14,13 @@ class NodeObject(Object):
             tree (TreeDiagram, optional): The owning tree diagram. Defaults to None.
 
         Keyword Args:
-            children (list, optional): A list of other NodeObjects
+            tree_children (list, optional): A list of other NodeObjects
             parent (list, optional): The parent NodeObject
         """
         super().__init__(**kwargs)
         self.tree = tree
-        self.children = kwargs.get("children", [])
-        self.parent = kwargs.get("parent", None)
+        self.tree_children = kwargs.get("tree_children", [])
+        self.tree_parent = kwargs.get("tree_parent", None)
         self.peers = []
         # self.level = kwargs.get("level", None)
         # self.peers = kwargs.get("peers", [])
@@ -41,19 +41,19 @@ class NodeObject(Object):
         self._tree = value
 
     @property
-    def parent(self):
-        """The parent NodeObject
+    def tree_parent(self):
+        """The parent NodeObject in the tree
 
         Returns:
             NodeObject
         """
-        return self._parent
+        return self._tree_parent
 
-    @parent.setter
-    def parent(self, value):
+    @tree_parent.setter
+    def tree_parent(self, value):
         if value is not None:
-            value.children.append(self)
-        self._parent = value
+            value.tree_children.append(self)
+        self._tree_parent = value
 
     def add_child(self, obj):
         """Add a new child to the object
@@ -61,8 +61,8 @@ class NodeObject(Object):
         Args:
             obj (NodeObject)
         """
-        self.children.append(obj)
-        obj._parent = self
+        self.tree_children.append(obj)
+        obj._tree_parent = self
 
     def add_peer(self, obj):
         if obj not in self.peers:
@@ -424,8 +424,8 @@ class TreeDiagram:
     def add_object(self, obj, **kwargs):
         if obj not in self.objects:
             obj.page = self.page
-            if "parent" in kwargs:
-                obj.parent = kwargs.get("parent")
+            if "tree_parent" in kwargs:
+                obj.tree_parent = kwargs.get("tree_parent")
             self.objects.append(obj)
 
     ###########################################################
@@ -434,21 +434,21 @@ class TreeDiagram:
 
     @property
     def roots(self):
-        return [x for x in self.objects if x.parent is None]
+        return [x for x in self.objects if x.tree_parent is None]
 
     def auto_layout(self):
-        def layout_child(parent):
+        def layout_child(tree_parent):
             grp = TreeGroup(tree=self)
-            grp.parent_object = parent
-            if len(parent.children) > 0:
-                # has children, go through each leaf and check its children
-                for leaf in parent.children:
-                    self.connect(parent, leaf)
-                    if len(leaf.children) > 0:
-                        # If this leaf has its own children then recursive call
-                        grp.add_object(layout_child(leaf))
+            grp.parent_object = tree_parent
+            if len(tree_parent.tree_children) > 0:
+                # has children, go through each child and check its children
+                for child in tree_parent.tree_children:
+                    self.connect(tree_parent, child)
+                    if len(child.tree_children) > 0:
+                        # If this child has its own children then recursive call
+                        grp.add_object(layout_child(child))
                     else:
-                        grp.add_object(leaf)
+                        grp.add_object(child)
 
                 # layout the row
                 grp = layout_group(grp)
@@ -459,11 +459,11 @@ class TreeDiagram:
         def layout_group(grp, pos=self.origin):
             pos = self.origin
 
-            for leaf in grp.objects:
-                if leaf is not grp.parent_object:
-                    leaf.position = pos
+            for obj in grp.objects:
+                if obj is not grp.parent_object:
+                    obj.position = pos
                     pos = self.move_in_level(
-                        pos, leaf.size_in_level + self.item_spacing
+                        pos, obj.size_in_level + self.item_spacing
                     )
             return grp
 
@@ -472,7 +472,7 @@ class TreeDiagram:
         #     level_space = (
         #         grp.size_of_level / 2
         #         + self.level_spacing
-        #         + parent.size_of_level / 2
+        #         + tree_parent.size_of_level / 2
         #     )
         #     pos = self.move_between_levels(pos, -level_space)
         #     parent.center_position = pos
@@ -564,8 +564,8 @@ class TreeDiagram:
         # Draw connections
         for lvl in self.objects.values():
             for obj in lvl:
-                if obj.parent is not None:
-                    self.connect(source=obj.parent, target=obj)
+                if obj.tree_parent is not None:
+                    self.connect(source=obj.tree_parent, target=obj)
 
     def write(self, **kwargs):
         self.file.write(**kwargs)


### PR DESCRIPTION
…n and .tree_parent to avoid conflicts with base Object class. This is technically a breaking API change but the break was introduced in 0.2.

closes #39 