### PR TITLE
Add property-based tests to classes.

### DIFF
--- a/src/drawpyo/diagram/base_diagram.py
+++ b/src/drawpyo/diagram/base_diagram.py
@@ -4,6 +4,7 @@ from os import path
 
 __all__ = [
     "DiagramBase",
+    "Geometry",
     "style_str_from_dict",
     "import_shape_database",
     "color_input_check",

--- a/src/drawpyo/diagram/edges.py
+++ b/src/drawpyo/diagram/edges.py
@@ -9,7 +9,7 @@ from .base_diagram import (
 )
 from .text_format import TextFormat
 
-__all__ = ["Edge", "BasicEdge", "EdgeGeometry", "Point"]
+__all__ = ["Edge", "BasicEdge", "EdgeGeometry", "EdgeLabel", "Point"]
 
 data = import_shape_database(
     file_name=path.join("formatting_database", "edge_styles.toml"), relative=True
@@ -119,8 +119,8 @@ class Edge(DiagramBase):
         self.edge = kwargs.get("edge", 1)
         self.targetPerimeterSpacing = kwargs.get("targetPerimeterSpacing", None)
         self.sourcePerimeterSpacing = kwargs.get("sourcePerimeterSpacing", None)
-        self.source = kwargs.get("source", None)
-        self.target = kwargs.get("target", None)
+        self._source = kwargs.get("source", None)
+        self._target = kwargs.get("target", None)
         self.entryX = kwargs.get("entryX", None)
         self.entryY = kwargs.get("entryY", None)
         self.entryDx = kwargs.get("entryDx", None)
@@ -596,9 +596,17 @@ class EdgeLabel(DiagramBase):
         )
 
         self.value = kwargs.get("value", "")
-        self.style = kwargs.get("style", self.default_style)
+        self._style = kwargs.get("style", self.default_style)
         self.vertex = kwargs.get("vertex", 1)
         self.connectable = kwargs.get("connectable", 1)
+
+    @property
+    def style(self):
+        return self._style
+
+    @style.setter
+    def style(self, value):
+        self._style = value
 
     @property
     def attributes(self):

--- a/src/drawpyo/diagram/text_format.py
+++ b/src/drawpyo/diagram/text_format.py
@@ -26,7 +26,7 @@ class TextFormat(DiagramBase):
             labelPosition (str, optional): The position of the object label ('left', 'center', or 'right')
             labelBackgroundColor (str, optional): The background color of the object label (#ffffff)
             labelBorderColor (str, optional): The border color of the object label (#ffffff)
-            fomrattedText (bool, optional): Whether to render the text as HTML formatted or not
+            formattedText (bool, optional): Whether to render the text as HTML formatted or not
 
         """
         super().__init__(**kwargs)

--- a/tests/diagram_tests/base_diagram_test.py
+++ b/tests/diagram_tests/base_diagram_test.py
@@ -1,10 +1,137 @@
-import drawpyo
+from hypothesis import given, strategies as st
+
+from drawpyo import XMLBase, Page
+from drawpyo.diagram import DiagramBase, Geometry
 
 
 def test_diagram_base_init():
-    test_page = drawpyo.Page()
-    test_dbase = drawpyo.diagram.DiagramBase(page=test_page)
+    test_page = Page()
+    test_dbase = DiagramBase(page=test_page)
 
     assert test_dbase.xml_class == "xml_tag"
     assert test_dbase.page == test_page
     assert test_dbase.style_attributes == ["html"]
+
+
+# Strategy for valid XMLBase-like values
+xml_parent_strategy = st.one_of(st.none(), st.just(Page()))
+page_strategy = st.one_of(st.none(), st.just(Page()))
+
+diagram_base_kwargs_strategy = st.fixed_dictionaries(
+    mapping={},  # No required keys
+    optional={
+        "id": st.just(st.integers()),
+        "xml_class": st.one_of(st.none(), st.text()),
+        "xml_parent": xml_parent_strategy,
+        "tag": st.one_of(st.none(), st.text()),
+        "page": page_strategy,
+    }
+)
+
+
+@given(kwargs=diagram_base_kwargs_strategy)
+def test_diagram_base(kwargs):
+    obj = DiagramBase(**kwargs)
+
+    # _id logic from XMLBase
+    if "id" in kwargs:
+        assert obj._id == kwargs["id"]
+    else:
+        assert isinstance(obj._id, int)
+
+    # xml_class
+    assert obj.xml_class == kwargs.get("xml_class", "xml_tag")
+
+    # tag
+    assert obj.tag == kwargs.get("tag", None)
+
+    # page
+    if "page" in kwargs:
+        assert obj.page == kwargs["page"]
+        if kwargs["page"] is not None:
+            assert isinstance(kwargs["page"], Page)
+    else:
+        assert obj.page is None
+
+    # _style_attributes
+    assert obj._style_attributes == ["html"]
+
+    # xml_parent override from DiagramBase
+    if "xml_parent" in kwargs:
+        assert obj.xml_parent == kwargs["xml_parent"]
+        if kwargs["xml_parent"] is not None:
+            assert isinstance(kwargs["xml_parent"], Page)
+    else:
+        assert obj.xml_parent is None
+
+
+# Strategy for optional dependencies
+xml_parent_strategy = st.one_of(st.none(), st.just(Page()))
+page_strategy = st.one_of(st.none(), st.just(Page()))
+parent_object_strategy = st.one_of(st.none(), st.just(Page()))
+
+geometry_kwargs_strategy = st.fixed_dictionaries(
+    mapping={},
+    optional={
+        "x": st.one_of(st.none(), st.integers(), st.floats(allow_nan=False, allow_infinity=False)),
+        "y": st.one_of(st.none(), st.integers(), st.floats(allow_nan=False, allow_infinity=False)),
+        "width": st.one_of(st.none(), st.integers(min_value=0, max_value=500)),
+        "height": st.one_of(st.none(), st.integers(min_value=0, max_value=500)),
+        "as_attribute": st.one_of(st.none(), st.text(min_size=1, max_size=10)),
+        "xml_class": st.one_of(st.none(), st.text(min_size=1, max_size=10)),
+        "tag": st.one_of(st.none(), st.text(min_size=1, max_size=10)),
+        "page": page_strategy,
+        "xml_parent": xml_parent_strategy,
+        "parent_object": parent_object_strategy,
+    }
+)
+
+
+@given(kwargs=geometry_kwargs_strategy)
+def test_geometry(kwargs):
+    obj = Geometry(**kwargs)
+
+    # xml_class is overridden
+    assert obj.xml_class == "mxGeometry"
+
+    # Inherited: tag
+    assert obj.tag == kwargs.get("tag", None)
+
+    # Inherited: page
+    if "page" in kwargs:
+        assert obj.page == kwargs["page"]
+        if kwargs["page"] is not None:
+            assert isinstance(obj.page, Page)
+    else:
+        assert obj.page is None
+
+    # Inherited: xml_parent
+    if "xml_parent" in kwargs:
+        assert obj.xml_parent == kwargs["xml_parent"]
+        if kwargs["xml_parent"] is not None:
+            assert isinstance(obj.xml_parent, Page)
+    else:
+        assert obj.xml_parent is None
+
+    # Geometry-specific
+    assert obj.parent_object == kwargs.get("parent_object", None)
+    assert obj.x == kwargs.get("x", 0)
+    assert obj.y == kwargs.get("y", 0)
+    assert obj.width == kwargs.get("width", 120)
+    assert obj.height == kwargs.get("height", 60)
+    assert obj.as_attribute == kwargs.get("as_attribute", "geometry")
+
+    # Derived properties
+    assert obj.size == (obj.width, obj.height)
+    assert obj.attributes == {
+        "x": obj.x,
+        "y": obj.y,
+        "width": obj.width,
+        "height": obj.height,
+        "as": obj.as_attribute,
+    }
+
+    # Check setter for size
+    obj.size = (200, 100)
+    assert obj.width == 200
+    assert obj.height == 100

--- a/tests/diagram_tests/edges_test.py
+++ b/tests/diagram_tests/edges_test.py
@@ -1,0 +1,192 @@
+from hypothesis import given, strategies as st
+
+from drawpyo import Page
+from drawpyo.diagram import Edge, DiagramBase, TextFormat, EdgeGeometry, EdgeLabel
+
+# Reusable strategies
+diagram_base_strategy = st.just(DiagramBase())
+text_strategy = st.text(min_size=1, max_size=20)
+bool_strategy = st.booleans()
+int_strategy = st.integers(min_value=0, max_value=1000)
+opacity_strategy = st.integers(min_value=0, max_value=100)
+label_position_strategy = st.floats(min_value=-1.0, max_value=1.0)
+stroke_width_strategy = st.integers(min_value=1, max_value=999)
+jetty_size_strategy = st.one_of(st.integers(min_value=0, max_value=100), st.just("auto"))
+color_strategy = st.one_of(
+    st.just("none"),
+    st.just("default"),
+    st.from_regex(r"^#[0-9a-fA-F]{6}$", fullmatch=True).map(str.strip)
+)
+connection_strategy = st.sampled_from(["line", "link", "arrow", "simple_arrow"])
+waypoints_strategy = st.sampled_from([
+    "straight", "orthogonal", "vertical", "horizontal", "isometric",
+    "isometric_vertical", "curved", "entity_relation"
+])
+pattern_strategy = st.sampled_from([
+    "solid",
+    "dashed_small", "dashed_medium", "dashed_large",
+    "dotted_small", "dotted_medium", "dotted_large"
+])
+line_ends_strategy = st.sampled_from([
+    "classic", "classicThin", "open", "openThin", "openAsync",
+    "block", "blockThin", "async", "oval", "diamond", "diamondThin",
+    "dash", "halfCircle", "cross", "circlePlus", "circle", "baseDash",
+    "ERone", "ERmandOne", "ERmany", "ERoneToMany", "ERzeroToOne",
+    "ERzeroToMany", "doubleBlock"
+])
+jump_style_strategy = st.sampled_from(["arc", "gap", "sharp", "line"])
+
+edge_kwargs_strategy = st.fixed_dictionaries(
+    mapping={},  # No required keys
+    optional={
+        "source": st.one_of(st.none(), diagram_base_strategy),
+        "target": st.one_of(st.none(), diagram_base_strategy),
+        "label": st.one_of(st.none(), text_strategy),
+        "label_position": st.one_of(st.none(), label_position_strategy),
+        "label_offset": st.one_of(st.none(), int_strategy),
+        "waypoints": waypoints_strategy,
+        "connection": st.one_of(st.none(), connection_strategy),
+        "pattern": st.one_of(st.none(), pattern_strategy),
+        "shadow": st.one_of(st.none(), bool_strategy),
+        "rounded": bool_strategy,
+        "flowAnimation": st.one_of(st.none(), bool_strategy),
+        "sketch": st.one_of(st.none(), bool_strategy),
+        "line_end_target": st.one_of(st.none(), line_ends_strategy),
+        "line_end_source": st.one_of(st.none(), line_ends_strategy),
+        "endFill_target": bool_strategy,
+        "endFill_source": bool_strategy,
+        "endSize": st.one_of(st.none(), int_strategy),
+        "startSize": st.one_of(st.none(), int_strategy),
+        "jettySize": jetty_size_strategy,
+        "targetPerimeterSpacing": st.one_of(st.none(), int_strategy),
+        "sourcePerimeterSpacing": st.one_of(st.none(), int_strategy),
+        "entryX": st.one_of(st.none(), st.integers(min_value=0, max_value=1)),
+        "entryY": st.one_of(st.none(), st.integers(min_value=0, max_value=1)),
+        "entryDx": st.one_of(st.none(), int_strategy),
+        "entryDy": st.one_of(st.none(), int_strategy),
+        "exitX": st.one_of(st.none(), st.integers(min_value=0, max_value=1)),
+        "exitY": st.one_of(st.none(), st.integers(min_value=0, max_value=1)),
+        "exitDx": st.one_of(st.none(), int_strategy),
+        "exitDy": st.one_of(st.none(), int_strategy),
+        "strokeColor": color_strategy,
+        "strokeWidth": stroke_width_strategy,
+        "fillColor": color_strategy,
+        "jumpStyle": st.one_of(st.none(), jump_style_strategy),
+        "jumpSize": st.one_of(st.none(), int_strategy),
+        "opacity": st.one_of(st.none(), opacity_strategy),
+    }
+)
+
+@given(kwargs=edge_kwargs_strategy)
+def test_edge(kwargs):
+    edge = Edge(**kwargs)
+
+    assert edge.xml_class == "mxCell"
+    assert isinstance(edge.text_format, TextFormat)
+    assert isinstance(edge.geometry, EdgeGeometry)
+    assert edge.edge == 1
+    assert edge.rounded in [0, 1]
+
+    # Spot-check that some passed values are preserved
+    if "source" in kwargs:
+        assert edge.source == kwargs["source"]
+    if "target" in kwargs:
+        assert edge.target == kwargs["target"]
+    if "waypoints" in kwargs:
+        assert edge.waypoints == kwargs["waypoints"]
+    if "connection" in kwargs:
+        assert edge.connection == kwargs["connection"]
+    if "pattern" in kwargs:
+        assert edge.pattern == kwargs["pattern"]
+    if "strokeColor" in kwargs:
+        assert edge.strokeColor == kwargs["strokeColor"]
+
+
+edge_geometry_kwargs_strategy = st.fixed_dictionaries(
+    mapping={},  # No required keys
+    optional={
+        "relative": st.booleans(),
+        "points": st.lists(
+            st.tuples(
+                st.floats(allow_nan=False, allow_infinity=False),
+                st.floats(allow_nan=False, allow_infinity=False)
+            ),
+            max_size=10
+        ),
+        "as_attribute": st.text(min_size=1, max_size=20),
+        "xml_parent": st.one_of(st.none(), st.just(Page())),
+        "page": st.one_of(st.none(), st.just(Page())),
+    }
+)
+
+@given(edge_kwargs=edge_geometry_kwargs_strategy)
+def test_edge_geometry(edge_kwargs):
+    obj = EdgeGeometry(**edge_kwargs)
+
+    # Check hardcoded xml_class
+    assert obj.xml_class == "mxGeometry"
+
+    # Check defaults or passed values
+    assert obj.relative == edge_kwargs.get("relative", 1)
+    assert obj.points == edge_kwargs.get("points", [])
+    assert obj.as_attribute == edge_kwargs.get("as_attribute", "geometry")
+    assert obj.page == edge_kwargs.get("page", None)
+    assert obj.xml_parent == edge_kwargs.get("xml_parent", None)
+
+
+# Optional inherited base class values
+page_strategy = st.one_of(st.none(), st.just(Page()))
+xml_parent_strategy = st.one_of(st.none(), st.just(Page()))
+
+# Strategy for EdgeLabel-specific kwargs
+edge_label_kwargs_strategy = st.fixed_dictionaries(
+    mapping={},  # No required keys
+    optional={
+        "value": st.text(min_size=0, max_size=50),
+        "style": st.text(min_size=5, max_size=200),
+        "vertex": st.integers(min_value=0, max_value=1),
+        "connectable": st.integers(min_value=0, max_value=1),
+        "tag": st.one_of(st.none(), st.text(min_size=1, max_size=10)),
+        "xml_class": st.one_of(st.none(), st.text(min_size=1, max_size=10)),
+        "page": page_strategy,
+        "xml_parent": xml_parent_strategy,
+    }
+)
+
+@given(kwargs=edge_label_kwargs_strategy)
+def test_edge_label(kwargs):
+    obj = EdgeLabel(**kwargs)
+
+    # xml_class should always be overridden to "mxCell"
+    assert obj.xml_class == "mxCell"
+
+    # Check default or provided values
+    assert obj.value == kwargs.get("value", "")
+    assert obj.style == kwargs.get("style", obj.default_style)
+    assert obj.vertex == kwargs.get("vertex", 1)
+    assert obj.connectable == kwargs.get("connectable", 1)
+
+    # Inherited: tag
+    assert obj.tag == kwargs.get("tag", None)
+
+    # Inherited: page
+    if "page" in kwargs:
+        assert obj.page == kwargs["page"]
+        if kwargs["page"] is not None:
+            assert isinstance(obj.page, Page)
+    else:
+        assert obj.page is None
+
+    # Inherited: xml_parent
+    if "xml_parent" in kwargs:
+        assert obj.xml_parent == kwargs["xml_parent"]
+        if kwargs["xml_parent"] is not None:
+            assert isinstance(obj.xml_parent, Page)
+    else:
+        assert obj.xml_parent is None
+
+    # Style attribute is fixed
+    assert obj._style_attributes == ["html"]
+
+    # attributes property
+    assert obj.attributes == []

--- a/tests/diagram_tests/object_test.py
+++ b/tests/diagram_tests/object_test.py
@@ -1,27 +1,99 @@
-import drawpyo
+from hypothesis import given, strategies as st
+
+from drawpyo import Page, XMLBase, File
+from drawpyo.diagram import Object, Geometry, TextFormat
+
 
 # TODO rewrite this test so it's independent of the order of the style attributes
 def test_obj_from_str():
-    file = drawpyo.File()
-    page = drawpyo.Page(file=file)
+    file = File()
+    page = Page(file=file)
 
     # style string
     test_style_str = "whiteSpace=wrap;rounded=1;fillColor=#6a00ff;strokeColor=#000000;dashed=0;html=1;fontColor=#ffffff;gradientColor=#FF33FF;strokeWidth=4;"
 
     # Create a new object and apply the style string
-    style_str_obj = drawpyo.diagram.Object(page=page)
+    style_str_obj = Object(page=page)
     style_str_obj.apply_style_string(test_style_str)
     # Check that the exported style string matches
     assert style_str_obj.style == test_style_str
 
     # Create another object using that as a template
-    template_obj = drawpyo.diagram.Object(page=page, template_object=style_str_obj)
+    template_obj = Object(page=page, template_object=style_str_obj)
     # Check that it has the same style
     assert template_obj.style == test_style_str
 
     # Create an object from the template a different way
-    template_obj2 = drawpyo.diagram.Object.create_from_template_object(
+    template_obj2 = Object.create_from_template_object(
         page=page, template_object=template_obj
     )
     # Check that it has the same style
     assert template_obj2.style == test_style_str
+
+
+position_strategy = st.tuples(st.integers(0, 1000), st.integers(0, 1000))
+text_strategy = st.text(min_size=0, max_size=50)
+int_strategy = st.integers(min_value=0, max_value=500)
+bool_strategy = st.booleans()
+opacity_strategy = st.integers(min_value=0, max_value=100)
+color_strategy = st.from_regex(r"^#[0-9a-fA-F]{6}$", fullmatch=True)
+line_pattern_strategy = st.sampled_from([
+    "solid",
+    "small_dash",
+    "medium_dash",
+    "large_dash",
+    "small_dot",
+    "medium_dot",
+    "large_dot",
+])
+object_strategy = st.builds(Object)
+
+@given(
+    kwargs=st.fixed_dictionaries(
+        mapping={
+            "value": text_strategy,
+            "position": position_strategy,
+        },
+        optional={
+            "position_rel_to_parent": position_strategy,
+            "width": int_strategy,
+            "height": int_strategy,
+            "vertex": st.integers(0, 1),
+            "aspect": st.one_of(st.none(), text_strategy),
+            "rounded": st.integers(0, 1),
+            "whiteSpace": text_strategy,
+            "fillColor": st.one_of(st.none(), color_strategy),
+            "opacity": st.one_of(st.none(), opacity_strategy),
+            "strokeColor": st.one_of(st.none(), color_strategy),
+            "glass": st.one_of(st.none(), bool_strategy),
+            "shadow": st.one_of(st.none(), bool_strategy),
+            "sketch": st.one_of(st.none(), bool_strategy),
+            "comic": st.one_of(st.none(), bool_strategy),
+            "autosize_to_children": bool_strategy,
+            "autocontract": bool_strategy,
+            "autosize_margin": int_strategy,
+            "children": st.lists(object_strategy, max_size=3),
+            "in_edges": st.lists(st.just(XMLBase())),
+            "out_edges": st.lists(st.just(XMLBase())),
+            "line_pattern": line_pattern_strategy,
+            "baseStyle": st.one_of(st.none(), text_strategy),
+            "text_format": st.just(TextFormat()),
+            "page": st.just(Page()),
+            "tag": st.one_of(st.none(), text_strategy),
+        }
+    )
+)
+def test_object(kwargs):
+    obj = Object(**kwargs)
+
+    assert isinstance(obj, Object)
+    assert isinstance(obj.geometry, Geometry)
+    assert isinstance(obj.text_format, TextFormat)
+    assert obj.xml_class == "mxCell"
+    assert isinstance(obj._style_attributes, list)
+    assert isinstance(obj.position, tuple)
+    assert isinstance(obj.width, int)
+    assert isinstance(obj.height, int)
+    assert isinstance(obj.value, str)
+    assert isinstance(obj.line_pattern, str)
+    assert obj.vertex in [0, 1]

--- a/tests/diagram_tests/text_format_test.py
+++ b/tests/diagram_tests/text_format_test.py
@@ -1,0 +1,53 @@
+from hypothesis import given, strategies as st
+from drawpyo.diagram import TextFormat
+
+# Strategies
+hex_color_strategy = st.from_regex(r"^#[0-9a-fA-F]{6}$", fullmatch=True)
+font_family_strategy = st.text(min_size=1, max_size=20)
+font_size_strategy = st.integers(min_value=1, max_value=200)
+align_strategy = st.sampled_from(["left", "center", "right"])
+vertical_align_strategy = st.sampled_from(["top", "middle", "bottom"])
+direction_strategy = st.sampled_from(["horizontal", "vertical"])
+bool_strategy = st.booleans()
+text_opacity_strategy = st.integers(min_value=0, max_value=100)
+spacing_strategy = st.integers(min_value=0, max_value=100)
+label_position_strategy = align_strategy
+
+text_format_strategy = st.fixed_dictionaries(
+    mapping={},
+    optional={
+        "fontColor": hex_color_strategy,
+        "fontFamily": font_family_strategy,
+        "fontSize": font_size_strategy,
+        "align": align_strategy,
+        "verticalAlign": vertical_align_strategy,
+        "direction": direction_strategy,
+        "formattedText": bool_strategy,
+        "bold": bool_strategy,
+        "italic": bool_strategy,
+        "underline": bool_strategy,
+        "labelPosition": label_position_strategy,
+        "labelBackgroundColor": hex_color_strategy,
+        "labelBorderColor": hex_color_strategy,
+        "textShadow": st.one_of(st.none(), bool_strategy),
+        "textOpacity": text_opacity_strategy,
+        "spacingTop": spacing_strategy,
+        "spacingLeft": spacing_strategy,
+        "spacingBottom": spacing_strategy,
+        "spacingRight": spacing_strategy,
+        "spacing": spacing_strategy,
+    }
+)
+
+
+@given(kwargs=text_format_strategy)
+def test_text_format(kwargs):
+    fmt = TextFormat(**kwargs)
+
+    # Verify that passed values are retained
+    for key, value in kwargs.items():
+        assert getattr(fmt, key) == value
+
+    # Always present attributes
+    assert isinstance(fmt._style_attributes, list)
+    assert "html" in fmt._style_attributes

--- a/tests/xml_base_test.py
+++ b/tests/xml_base_test.py
@@ -1,3 +1,5 @@
+from hypothesis import given, strategies as st
+
 import drawpyo
 
 
@@ -26,3 +28,30 @@ def test_XMLBase_xml_ify():
     assert test_obj.xml_ify("&") == "&amp;"
     assert test_obj.xml_ify('"') == "&quot;"
     assert test_obj.xml_ify("'") == "&apos;"
+
+
+
+xmlbase_kwargs_strategy = st.fixed_dictionaries(
+    mapping={},  # No required keys
+    optional={
+        "id": st.just(st.integers()),
+        "xml_class": st.one_of(st.text(), st.none()),
+        "xml_parent": st.one_of(st.integers(), st.text(), st.none()),
+        "tag": st.one_of(st.text(), st.none()),
+    }
+)
+
+
+@given(kwargs=xmlbase_kwargs_strategy)
+def test_xmlbase(kwargs):
+    obj = drawpyo.XMLBase(**kwargs)
+
+    # 'id' default is generated from id(self)
+    if "id" in kwargs:
+        assert obj._id == kwargs["id"]
+    else:
+        assert isinstance(obj._id, int)
+
+    assert obj.xml_class == kwargs.get("xml_class", "xml_tag")
+    assert obj.xml_parent == kwargs.get("xml_parent", None)
+    assert obj.tag == kwargs.get("tag", None)


### PR DESCRIPTION
Add property-based tests to explore argument combinations and types

This commit introduces property-based tests using Hypothesis to systematically and rigorously test a wide range of keyword argument combinations and input types for the core classes.

Unlike traditional unit tests that check a few hardcoded inputs, Hypothesis generates many random but valid combinations of arguments based on defined strategies. This allows us to:
	•	Discover edge cases and invalid input combinations
	•	Verify that the current code behaves consistently and predictably across a wide input space
	•	Establish a solid baseline before adding stricter validation

⸻

This is step 1 of 4 in a proposed plan to implement strict argument validation using Pydantic. Currently, arguments are accepted and processed without formal type checks or constraints.

Proposed steps:
	1.	✅ Create property-based tests for core classes (this commit)
→ ensures behavior is well-understood and non-breaking before applying changes
	2.	🧠 Add type hinting to core classes
	3.	🧪 Introduce Pydantic models to validate accepted arguments
	•	Define types, allowed values, and constraints
	•	Externalize validation logic currently embedded in classes
	4.	🔁 Add GitHub Actions pipeline to run tests on merge

⸻

This overall approach will make the code:
	•	Clearer (via explicit typing and validation)
	•	More modular (by separating validation concerns)
	•	More robust (through automated property-based and CI testing)