### PR TITLE
Create TreeDiagram from data dictionary

### DIFF
--- a/docs/diagram_types/tree_diagrams.md
+++ b/docs/diagram_types/tree_diagrams.md
@@ -72,14 +72,35 @@ With some more additions, the resulting diagram renders as:
 
 ## Create a Tree from a Dictionary
 
-TreeDiagram supports creating an entire tree structure directly from a nested dictionary or list. This allows you to generate trees programmatically without manually creating every NodeObject.
+`TreeDiagram` supports creating an entire tree structure directly from a nested dictionary or list. This allows you to generate trees programmatically without manually creating every `NodeObject`.
 
 ### Rules for dict/list conversion
 
-* **Dicts** represent branching nodes. Each key becomes a **category node**, and its value is recursively processed as its children.
-* **Lists or tuples** represent multiple siblings under the same parent. Each element is recursively added as a child.
-* **Scalars (`str`, `int`, `float`)** are treated as leaf nodes.
-* **Unsupported types** will raise a `TypeError`.
+| Input Type                         | Behavior                                                                                      |
+| ---------------------------------- | --------------------------------------------------------------------------------------------- |
+| **Dict**                           | Each key becomes a **category node**, and its value is recursively processed as its children. |
+| **List / Tuple**                   | Each element becomes a sibling under the same parent.                                         |
+| **Scalar (`str`, `int`, `float`)** | Treated as a **leaf node**.                                                                   |
+| **Unsupported types**              | Raises a `TypeError`.                                                                         |
+
+---
+
+### Coloring Nodes
+
+You can control node colors using the `colors` list and `coloring` mode.
+
+| Parameter  | Description                                                   | Options / Default                       |
+| ---------- | ------------------------------------------------------------- | --------------------------------------- |
+| `colors`   | List of `ColorScheme`, `StandardColor`, or color hex strings. | Default: `None`                         |
+| `coloring` | Method used to assign colors to nodes.                        | `"depth"` (default), `"hash"`, `"type"` |
+
+**Coloring Modes**
+
+| Mode    | Description                                                           |
+| ------- | --------------------------------------------------------------------- |
+| `depth` | Colors nodes based on their **depth in the tree**.                    |
+| `hash`  | Colors nodes based on a **hash of their value** (stable across runs). |
+| `type`  | Colors nodes based on **node type**: category, list item, or leaf.    |
 
 ---
 
@@ -99,7 +120,9 @@ tree = TreeDiagram.from_dict(
     data,
     file_path="~/Test Drawpyo Charts",
     file_name="Minimal Tree.drawio",
-    direction="down"
+    direction="down",
+    colors=["#DDDDDD","#BBBBBB"],
+    coloring="depth"
 )
 
 tree.write()

--- a/etc/development scripts/generate_tree_from_dict.py
+++ b/etc/development scripts/generate_tree_from_dict.py
@@ -1,4 +1,5 @@
 from drawpyo.diagram_types.tree import TreeDiagram
+import drawpyo
 from os import path
 
 data = {
@@ -20,12 +21,32 @@ data = {
     }
 }
 
+color_schemes = [
+    drawpyo.ColorScheme(
+        font_color=drawpyo.StandardColor.GRAY1,
+        stroke_color="#3C755E",
+        fill_color="#5BA283",
+    ),
+    drawpyo.ColorScheme(
+        font_color=drawpyo.StandardColor.GRAY1,
+        stroke_color="#3C756E",
+        fill_color="#5BA299",
+    ),
+    drawpyo.StandardColor.CRIMSON4,
+    drawpyo.ColorScheme(
+        font_color=drawpyo.StandardColor.GRAY1,
+        stroke_color="#3C4F75",
+        fill_color="#5B6EA2",
+    ),
+    "#A25B99",
+]
 
 tree = TreeDiagram.from_dict(
     data,
     file_path=path.join(path.expanduser("~"), "Test Drawpyo Charts"),
     file_name="Coffee Grinders from Dict.drawio",
     direction="down",
+    colors=color_schemes,
 )
 
 tree.write()


### PR DESCRIPTION
TreeDiagram supports creating an entire tree structure directly from a nested dictionary or list. This allows you to generate trees programmatically without manually creating every NodeObject.

### Rules for dict/list conversion

* **Dicts** represent branching nodes. Each key becomes a **category node**, and its value is recursively processed as its children.
* **Lists or tuples** represent multiple siblings under the same parent. Each element is recursively added as a child.
* **Scalars (`str`, `int`, `float`)** are treated as leaf nodes.
* **Unsupported types** will raise a `TypeError`.

---

### Example

```python
from drawpyo.diagram_types import TreeDiagram

data = {
    "Root": {
        "Branch A": ["Leaf 1", "Leaf 2"],
        "Branch B": ["Leaf 3"]
    }
}

tree = TreeDiagram.from_dict(
    data,
    file_path="~/Test Drawpyo Charts",
    file_name="Minimal Tree.drawio",
    direction="down"
)

tree.write()
```

Additionally, users can provide a list of  `colors` and a `coloring` method.
The color list can contain hex strings, StandardColors or ColorSchemes.
Currently there are three coloring methods implemented:
1. "depth" - Color nodes based on their depth in the tree. (default)
2. "hash" - Color nodes based on a hash of their value. (same values will get same colors)
3. "type" - Color nodes based on their type (category, list_item, leaf).

<img width="599" height="596" alt="image" src="https://github.com/user-attachments/assets/c5bec837-8715-48cb-9532-2c71651ed1be" />
