### PR TITLE
Structured tests by class

### DIFF
--- a/tests/xml_base_test.py
+++ b/tests/xml_base_test.py
@@ -1,28 +1,69 @@
+import pytest
 import drawpyo
 
 
-def test_XMLBase_init() -> None:
-    test_obj = drawpyo.XMLBase()
-    assert test_obj.id == id(test_obj)
-    assert test_obj.xml_class == "xml_tag"
-    assert test_obj.attributes == {"id": id(test_obj), "parent": None}
+class TestXMLBaseInit:
+    def test_default_values(self) -> None:
+        obj = drawpyo.XMLBase()
+        assert obj.id == id(obj)
+        assert obj.xml_class == "xml_tag"
+        assert obj.xml_parent is None
+        assert obj.tag is None
+        assert obj.tooltip is None
+
+    def test_custom_id(self) -> None:
+        obj = drawpyo.XMLBase(id="custom_id")
+        assert obj.id == "custom_id"
+
+    def test_custom_xml_class(self) -> None:
+        obj = drawpyo.XMLBase(xml_class="mxCell")
+        assert obj.xml_class == "mxCell"
 
 
-def test_XMLBase_tags() -> None:
-    test_obj = drawpyo.XMLBase(xml_class="mxCell")
-    expected_xml_open_tag = f'<mxCell id="{test_obj.id}">'
-    expected_xml_close_tag = f"</mxCell>"
-    expected_xml = f'<mxCell id="{test_obj.id}" />'
-    assert test_obj.xml_open_tag == expected_xml_open_tag
-    assert test_obj.xml_close_tag == expected_xml_close_tag
-    assert test_obj.xml == expected_xml
+class TestXMLBaseAttributes:
+    def test_attributes(self) -> None:
+        obj = drawpyo.XMLBase()
+        assert obj.attributes == {"id": obj.id, "parent": None}
 
 
-def test_XMLBase_xml_ify() -> None:
-    test_obj = drawpyo.XMLBase(xml_class="mxCell")
+class TestXMLBaseTags:
+    def test_basic_open_tag(self) -> None:
+        obj = drawpyo.XMLBase(xml_class="mxCell")
+        assert obj.xml_open_tag == f'<mxCell id="{obj.id}">'
 
-    assert test_obj.xml_ify(">") == "&gt;"
-    assert test_obj.xml_ify("<") == "&lt;"
-    assert test_obj.xml_ify("&") == "&amp;"
-    assert test_obj.xml_ify('"') == "&quot;"
-    assert test_obj.xml_ify("'") == "&apos;"
+    def test_basic_close_tag(self) -> None:
+        obj = drawpyo.XMLBase(xml_class="mxCell")
+        assert obj.xml_close_tag == "</mxCell>"
+
+    def test_basic_xml(self) -> None:
+        obj = drawpyo.XMLBase(xml_class="mxCell")
+        assert obj.xml == f'<mxCell id="{obj.id}" />'
+
+
+class TestXmlIfy:
+    @pytest.mark.parametrize(
+        "input_str,expected",
+        [
+            (">", "&gt;"),
+            ("<", "&lt;"),
+            ("&", "&amp;"),
+            ('"', "&quot;"),
+            ("'", "&apos;"),
+            ("", ""),
+            ("hello", "hello"),
+            ("<div>&test</div>", "&lt;div&gt;&amp;test&lt;/div&gt;"),
+        ],
+    )
+    def test_xml_ify(self, input_str: str, expected: str) -> None:
+        obj = drawpyo.XMLBase()
+        assert obj.xml_ify(input_str) == expected
+
+
+class TestTranslateTxt:
+    def test_translate_txt(self) -> None:
+        result = drawpyo.XMLBase.translate_txt("abc", {"a": "X", "c": "Z"})
+        assert result == "XbZ"
+
+    def test_translate_txt_no_replacements(self) -> None:
+        result = drawpyo.XMLBase.translate_txt("hello", {})
+        assert result == "hello"


### PR DESCRIPTION
### Why this change is needed?

- Each group of tests in a separate class
- Added parameterization for `test_xml_ify` via `@pytest.mark.parametrize`
- Broken large tests into atomic ones
- Expanded coverage