### PR TITLE
Adding missing documentation for BinaryTreeDiagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Drawpyo also provides higher-level functionality that goes beyond what the Draw.
 Currently, Drawpyo supports:
 
 * **Tree Diagrams**
+* **Binary Tree Diagrams**
 * **Bar Charts**
 * **Pie Charts**
 
@@ -83,5 +84,6 @@ For more details, refer to the [documentation](https://merrimanind.github.io/dra
 Work has also begun on additional diagram types, including:
 
 * Automatic class/object/inheritance diagrams from a Python module
+* Directed and undirected graphs from adjacency lists
 * Flowcharts
 * Process diagrams

--- a/docs/api/binary_tree_diagram/binarynodeobject.md
+++ b/docs/api/binary_tree_diagram/binarynodeobject.md
@@ -1,0 +1,5 @@
+# BinaryNodeObject
+
+::: src.drawpyo.diagram_types.binary_tree.BinaryNodeObject
+    options:
+        show_root_heading: true

--- a/docs/api/binary_tree_diagram/binarytreediagram.md
+++ b/docs/api/binary_tree_diagram/binarytreediagram.md
@@ -1,0 +1,6 @@
+# BinaryTreeDiagram
+
+::: src.drawpyo.diagram_types.binary_tree.BinaryTreeDiagram
+    options:
+        show_root_heading: true
+        

--- a/docs/diagram_types/binary_tree_diagrams.md
+++ b/docs/diagram_types/binary_tree_diagrams.md
@@ -1,0 +1,170 @@
+# Binary Tree Diagrams
+
+Binary trees are one of the most common hierarchical structures, and this module provides a specialized pair of classes — **BinaryNodeObject** and **BinaryTreeDiagram** — designed to make creating, linking, and laying out binary trees convenient and safe.
+
+BinaryNodeObject enforces the strict "at most two children" rule and exposes intuitive `left` and `right` properties. BinaryTreeDiagram extends TreeDiagram with binary-friendly defaults and helper methods.
+
+---
+
+## Create a Binary Tree
+
+To get started, import the binary tree types and create a `BinaryTreeDiagram`:
+
+```python
+from drawpyo.diagram_types import BinaryTreeDiagram
+
+tree = BinaryTreeDiagram(
+    file_path="path/to/diagram",
+    file_name="Binary Tree.drawio",
+)
+```
+
+There are a number of configuration parameters available to fine tune the layout of the BinaryTreeDiagram:
+
+| Parameter     | Effect                                    | Default    |
+| ------------- | ----------------------------------------- | ---------- |
+| level_spacing | Vertical spacing between levels           | 80         |
+| item_spacing  | Horizontal spacing between sibling groups | 20         |
+| group_spacing | Spacing between unrelated groups          | 30         |
+| link_style    | Edge connection style                     | "straight" |
+| padding       | Spacing between objects within a group    | 10         |
+
+---
+
+## Add Nodes
+
+Binary trees use **BinaryNodeObject**, a subclass of NodeObject that provides two dedicated child slots: `left` and `right`.
+
+```python
+from drawpyo.diagram_types import BinaryNodeObject
+
+root = BinaryNodeObject(tree=tree, value="Root")
+left = BinaryNodeObject(tree=tree, value="Left Branch")
+right = BinaryNodeObject(tree=tree, value="Right Branch")
+```
+
+### Using the `left` and `right` setters
+
+Every BinaryNodeObject has:
+
+* exactly **two child slots**, always present
+* direct accessors: `node.left` and `node.right`
+
+Assign children:
+
+```python
+root.left = left
+root.right = right
+```
+
+Changing a child's side automatically fixes its parent relationship:
+
+```python
+root.left = right     # reassigns and detaches from old parent
+```
+
+Setting a side to `None` removes the child:
+
+```python
+root.right = None
+```
+
+---
+
+## Using BinaryTreeDiagram convenience methods
+
+BinaryTreeDiagram provides small helpers to ensure consistency and type safety:
+
+```python
+tree.add_left(root, left)
+tree.add_right(root, right)
+```
+
+Both methods:
+
+* ensure parent and child are BinaryNodeObjects
+* automatically register both under the same `BinaryTreeDiagram`
+
+---
+
+## Rules and Guarantees
+
+BinaryNodeObject enforces strict binary-tree behavior.
+
+### Child Slot Normalization
+
+Nodes always maintain exactly two slots:
+
+```
+[left, right]
+```
+
+If you supply fewer than two children on creation:
+
+```python
+node = BinaryNodeObject(tree_children=[child])
+```
+
+…it becomes:
+
+```
+[child, None]
+```
+
+If you supply more than two:
+
+```python
+BinaryNodeObject(tree_children=[a, b, c])
+```
+
+→ Raises `ValueError`.
+
+### Moving Nodes Between Parents
+
+Assigning a node as a child:
+
+* detaches it from any existing parent
+* prevents a node from occupying *both* sides at once
+* prevents more than two unique children
+
+### Parent Safety
+
+BinaryTreeDiagram forbids attaching non-binary nodes:
+
+```python
+tree.add_left(parent, not_a_binary_node)
+```
+→ Raises `TypeError`.
+
+---
+
+## Full Example
+
+```python
+from drawpyo.diagram_types import BinaryTreeDiagram, BinaryNodeObject
+
+# Create the diagram
+tree = BinaryTreeDiagram(
+    file_path="~/Binary Trees",
+    file_name="SimpleBinary.drawio"
+)
+
+# Root
+root = BinaryNodeObject(tree=tree, value="Root Node")
+
+# Children
+a = BinaryNodeObject(tree=tree, value="Left Child")
+b = BinaryNodeObject(tree=tree, value="Right Child")
+
+# Attach via setters
+root.left = a
+root.right = b
+
+# Further branching
+a.left  = BinaryNodeObject(tree=tree, value="A1")
+a.right = BinaryNodeObject(tree=tree, value="A2")
+b.left  = BinaryNodeObject(tree=tree, value="B1")
+
+tree.auto_layout()
+tree.write()
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
     - Shape Libraries: usage/shape_libs.md
   - Custom Diagram Types:
     - Tree Diagrams: diagram_types/tree_diagrams.md
+    - Binary Tree Diagrams: diagram_types/binary_tree_diagrams.md
     - Bar Charts: diagram_types/bar_charts.md
     - Bar Charts: diagram_types/pie_charts.md
   - API:
@@ -43,5 +44,8 @@ nav:
       - Tree Diagram:
         - TreeDiagram: api/tree_diagram/treediagram.md
         - NodeObject: api/tree_diagram/nodeobject.md
+      - Binary Tree Diagram:
+        - BinaryTreeDiagram: api/binary_tree_diagram/binarytreediagram.md
+        - BinaryNodeObject: api/binary_tree_diagram/binarynodeobject.md
       - Bar Chart: api/bar_chart/barchart.md
       - Pie Chart: api/pie_chart/piechart.md

--- a/src/drawpyo/diagram_types/binary_tree.py
+++ b/src/drawpyo/diagram_types/binary_tree.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional, Tuple, Dict, Any
+from typing import List, Optional, Dict, Any
 
 from .tree import NodeObject, TreeDiagram
 
@@ -156,3 +156,13 @@ class BinaryTreeDiagram(TreeDiagram):
 
     def add_right(self, parent: BinaryNodeObject, child: BinaryNodeObject) -> None:
         self._attach(parent, child, "right")
+
+    @classmethod
+    def from_dict(self, data: Dict[str, Any], **kwargs) -> BinaryTreeDiagram:
+        """
+        Create a BinaryTreeDiagram from a nested dictionary structure.
+
+        Each key represents a node, and its value is either None or another
+        dictionary with up to two keys (left and right children).
+        """
+        pass  # Implementation would go here


### PR DESCRIPTION
- Missing documentation
- Temporarily pass unimplemented .from_dict()