### PR TITLE
added xml escaping to control characters

### DIFF
--- a/src/drawpyo/xml_base.py
+++ b/src/drawpyo/xml_base.py
@@ -7,6 +7,12 @@ xmlize["&"] = "&amp;"
 xmlize['"'] = "&quot;"
 xmlize["'"] = "&apos;"
 
+# Escape control characters
+xmlize["\n"] = "&#xa;"  # Newline
+xmlize["\t"] = "&#x9;"  # Tab
+xmlize["\r"] = "&#xd;"  # Carriage return
+
+
 # When saving Draw.io uses this for single quotes and also has some funky XML character escaping (double escaping ampersands) but handles normal XML escapes (above) fine on loading
 # xmlize["'"] = "&#39;"
 # xmlize['"'] = "&#34;"


### PR DESCRIPTION
Hi @ibirothe, escaping XML on whitespace control characters as discussed in https://github.com/MerrimanInd/drawpyo/issues/16

