### PR TITLE
Value/Label Redaction and Restoration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,16 @@ To run the test suite enter in your terminal:
 uv run tox
 ```
 
+#### Pull Requests
+
+Ensure there is an existing issue describing the bug, feature, or improvement. If not, create one and discuss the approach before starting work. Fork the repository and create a feature branch from the `dev` branch.
+
+**PR Requirements:**
+- Code builds successfully and all tests pass.
+- New functionality includes appropriate tests.
+- Documentation is updated if behavior or usage has changed.
+- No unnecessary formatting or unrelated refactoring is included.
+
 #### Building
 
 Building can also be done with `uv`! The build system (flit) is specified in the `pyproject.toml` file and should have been installed automatically by `uv`. To build the wheels enter in your terminal:

--- a/etc/development scripts/load_and_redact.py
+++ b/etc/development scripts/load_and_redact.py
@@ -17,7 +17,8 @@ drawio_input_path = (
 ).resolve()
 
 redaction_map_path = base_dir / "redaction_map.json"
-drawio_output_path = base_dir / "Redacted Drawio File.drawio"
+drawio_redacted_output_path = base_dir / "Redacted Drawio File.drawio"
+drawio_restored_output_path = base_dir / "Restored Drawio File.drawio"
 
 # --------------------------------------------------
 # Load diagram
@@ -35,22 +36,50 @@ redacted_diagram = drawpyo.utils.redact_values(
 )
 
 # --------------------------------------------------
-# Create output file
+# Write redacted draw.io file
 # --------------------------------------------------
 
-file = drawpyo.File()
-file.file_path = str(base_dir)
-file.file_name = drawio_output_path.name
+redacted_file = drawpyo.File()
+redacted_file.file_path = str(base_dir)
+redacted_file.file_name = drawio_redacted_output_path.name
 
-page = drawpyo.Page(file=file)
+redacted_page = drawpyo.Page(file=redacted_file)
 
 # Add shapes
 for shape in redacted_diagram.shapes:
-    shape.page = page
+    shape.page = redacted_page
 
 # Add edges
 for edge in redacted_diagram.edges:
-    edge.page = page
+    edge.page = redacted_page
 
-# Write draw.io file
-file.write()
+redacted_file.write()
+
+# --------------------------------------------------
+# Restore diagram from map
+# --------------------------------------------------
+
+restored_diagram = drawpyo.utils.restore_values(
+    redacted_diagram,
+    map_file_path=redaction_map_path,
+)
+
+# --------------------------------------------------
+# Write restored (unredacted) draw.io file
+# --------------------------------------------------
+
+restored_file = drawpyo.File()
+restored_file.file_path = str(base_dir)
+restored_file.file_name = drawio_restored_output_path.name
+
+restored_page = drawpyo.Page(file=restored_file)
+
+# Add shapes
+for shape in restored_diagram.shapes:
+    shape.page = restored_page
+
+# Add edges
+for edge in restored_diagram.edges:
+    edge.page = restored_page
+
+restored_file.write()

--- a/etc/development scripts/load_and_redact.py
+++ b/etc/development scripts/load_and_redact.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import drawpyo
+from drawpyo import load_diagram
+
+# --------------------------------------------------
+# Paths
+# --------------------------------------------------
+
+base_dir = Path.home() / "Test Drawpyo Charts"
+base_dir.mkdir(parents=True, exist_ok=True)
+
+drawio_input_path = (
+    Path(__file__).parent
+    / ".."
+    / "reference drawio charts"
+    / "Pourover Flowchart.drawio"
+).resolve()
+
+redaction_map_path = base_dir / "redaction_map.json"
+drawio_output_path = base_dir / "Redacted Drawio File.drawio"
+
+# --------------------------------------------------
+# Load diagram
+# --------------------------------------------------
+
+diagram = load_diagram(drawio_input_path)
+
+# --------------------------------------------------
+# Redact diagram + write map
+# --------------------------------------------------
+
+redacted_diagram = drawpyo.utils.redact_values(
+    diagram,
+    map_file_path=redaction_map_path,
+)
+
+# --------------------------------------------------
+# Create output file
+# --------------------------------------------------
+
+file = drawpyo.File()
+file.file_path = str(base_dir)
+file.file_name = drawio_output_path.name
+
+page = drawpyo.Page(file=file)
+
+# Add shapes
+for shape in redacted_diagram.shapes:
+    shape.page = page
+
+# Add edges
+for edge in redacted_diagram.edges:
+    edge.page = page
+
+# Write draw.io file
+file.write()

--- a/src/drawpyo/__init__.py
+++ b/src/drawpyo/__init__.py
@@ -7,7 +7,7 @@ from .utils.color_scheme import ColorScheme
 from .utils.logger import logger
 from .utils.page_sizes import PageSize
 
-from .drawio_import import load_diagram
+from .drawio_import import load_diagram, ParsedDiagram
 
 from . import utils
 from . import diagram
@@ -27,6 +27,7 @@ __all__ = [
     diagram_types,
     drawio_import,
     load_diagram,
+    ParsedDiagram,
 ]
 
 __version__ = "0.2.4"

--- a/src/drawpyo/diagram/edges.py
+++ b/src/drawpyo/diagram/edges.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from os import path
 from typing import Optional, Dict, Any, List, Union, Tuple
 from ..utils.logger import logger

--- a/src/drawpyo/diagram/extended_objects.py
+++ b/src/drawpyo/diagram/extended_objects.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List as ListType, Optional, Any, Union
 from .objects import Object, object_from_library
 

--- a/src/drawpyo/diagram/objects.py
+++ b/src/drawpyo/diagram/objects.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from os import path
 from typing import Optional, Dict, Any, List, Union, Tuple
 from ..utils.logger import logger

--- a/src/drawpyo/diagram/text_format.py
+++ b/src/drawpyo/diagram/text_format.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Dict, Any, Union
 from ..utils.logger import logger
 from .base_diagram import DiagramBase

--- a/src/drawpyo/diagram_types/bar_chart.py
+++ b/src/drawpyo/diagram_types/bar_chart.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, Union, Optional
 from copy import deepcopy
 from ..diagram.objects import Object, Group

--- a/src/drawpyo/diagram_types/class_diagram.py
+++ b/src/drawpyo/diagram_types/class_diagram.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Any
 
 from .tree import NodeObject, TreeGroup, TreeDiagram

--- a/src/drawpyo/diagram_types/legend.py
+++ b/src/drawpyo/diagram_types/legend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Union, Optional
 from copy import deepcopy
 from ..diagram.objects import Object, Group

--- a/src/drawpyo/diagram_types/pie_chart.py
+++ b/src/drawpyo/diagram_types/pie_chart.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, Union, Optional
 from copy import deepcopy
 from ..diagram.objects import Object, Group

--- a/src/drawpyo/drawio_import/__init__.py
+++ b/src/drawpyo/drawio_import/__init__.py
@@ -1,2 +1,4 @@
 from .raw import RawMxCell, RawGeometry
-from .drawio_parser import load_diagram
+from .drawio_parser import load_diagram, ParsedDiagram
+
+__all__ = [ParsedDiagram, RawGeometry, RawMxCell]

--- a/src/drawpyo/drawio_import/drawio_parser.py
+++ b/src/drawpyo/drawio_import/drawio_parser.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Dict, List, Optional
 from dataclasses import dataclass, field
 
 from .raw import RawMxCell, RawGeometry
-from drawpyo import logger
+from drawpyo.utils import logger
 from drawpyo.diagram import Object, Edge, DiagramBase
 
 

--- a/src/drawpyo/drawio_import/raw.py
+++ b/src/drawpyo/drawio_import/raw.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Optional, List, Tuple
 

--- a/src/drawpyo/file.py
+++ b/src/drawpyo/file.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional, Any, Union, Dict
 from .xml_base import XMLBase
 from datetime import datetime

--- a/src/drawpyo/page.py
+++ b/src/drawpyo/page.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional, Any, Union, Dict
 from .xml_base import XMLBase
 from .utils.logger import logger

--- a/src/drawpyo/utils/__init__.py
+++ b/src/drawpyo/utils/__init__.py
@@ -2,6 +2,6 @@ from .logger import logger
 from .standard_colors import StandardColor
 from .color_scheme import ColorScheme
 from .page_sizes import PageSize
-from .redact import redact_values
+from .redact import redact_values, restore_values
 
-__all__ = [logger, StandardColor, ColorScheme, PageSize, redact_values]
+__all__ = [logger, StandardColor, ColorScheme, PageSize, redact_values, restore_values]

--- a/src/drawpyo/utils/__init__.py
+++ b/src/drawpyo/utils/__init__.py
@@ -2,5 +2,6 @@ from .logger import logger
 from .standard_colors import StandardColor
 from .color_scheme import ColorScheme
 from .page_sizes import PageSize
+from .redact import redact_values
 
-__all__ = [logger, StandardColor, ColorScheme, PageSize]
+__all__ = [logger, StandardColor, ColorScheme, PageSize, redact_values]

--- a/src/drawpyo/utils/color_scheme.py
+++ b/src/drawpyo/utils/color_scheme.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import Union
 import re
 from .logger import logger

--- a/src/drawpyo/utils/logger.py
+++ b/src/drawpyo/utils/logger.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 """Set the logging level.

--- a/src/drawpyo/utils/page_sizes.py
+++ b/src/drawpyo/utils/page_sizes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 
 

--- a/src/drawpyo/utils/redact.py
+++ b/src/drawpyo/utils/redact.py
@@ -1,0 +1,36 @@
+from drawpyo.diagram import Object, Edge
+import json
+
+
+def redact_text(text: str | None) -> str | None:
+    if text is None:
+        return None
+    return "".join(ch if ch.isspace() else "X" for ch in text)
+
+
+def redact_values(diagram, map_file_path):
+    id_value_map: dict[str, str] = {}
+
+    for node in diagram.shapes + diagram.edges:
+        if isinstance(node, Object):
+            if node.value is None:
+                continue
+            id_value_map[node.id] = node.value
+            node.value = redact_text(node.value)
+
+        elif isinstance(node, Edge):
+            if node.label is None:
+                continue
+            id_value_map[node.id] = node.label
+            node.label = redact_text(node.label)
+
+    with open(map_file_path, "w", encoding="utf-8") as f:
+        json.dump(
+            id_value_map,
+            f,
+            indent=2,
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+
+    return diagram

--- a/src/drawpyo/utils/redact.py
+++ b/src/drawpyo/utils/redact.py
@@ -1,4 +1,6 @@
 from drawpyo.diagram import Object, Edge
+from drawpyo.utils import logger
+from pathlib import Path
 import json
 
 
@@ -32,5 +34,42 @@ def redact_values(diagram, map_file_path):
             ensure_ascii=False,
             sort_keys=True,
         )
+
+    logger.info(f"👤 Reaction map saved to: '{map_file_path}'")
+    return diagram
+
+
+def restore_values(diagram, map_file_path: Path):
+    if not map_file_path.exists():
+        raise FileNotFoundError(f"Restore map not found: {map_file_path}")
+
+    with map_file_path.open("r", encoding="utf-8") as f:
+        id_value_map: dict[str, str] = json.load(f)
+
+    restored = 0
+    missing = 0
+
+    for cell_id, original_value in id_value_map.items():
+        matched_element = None
+
+        for element in diagram.shapes + diagram.edges:
+            if str(element.id) == str(cell_id):
+                matched_element = element
+                break
+
+        if matched_element is None:
+            missing += 1
+            logger.warning(f" No matching object/edge found: '{cell_id}'")
+            continue
+
+        if isinstance(matched_element, Object):
+            matched_element.value = original_value
+            restored += 1
+
+        elif isinstance(matched_element, Edge):
+            matched_element.label = original_value
+            restored += 1
+
+    logger.info(f"🔄 Restore complete: restored={restored}, missing={missing}")
 
     return diagram

--- a/src/drawpyo/utils/redact.py
+++ b/src/drawpyo/utils/redact.py
@@ -1,16 +1,43 @@
+from __future__ import annotations
+
 from drawpyo.diagram import Object, Edge
+from drawpyo.drawio_import import ParsedDiagram
 from drawpyo.utils import logger
 from pathlib import Path
 import json
 
 
-def redact_text(text: str | None) -> str | None:
+def _redact_text(text: str | None) -> str:
+    """
+    Redact a text string by replacing all non-whitespace characters with 'X'.
+
+    Args:
+        text: The input text to redact, or None.
+
+    Returns:
+        The redacted text with non-whitespace characters replaced by 'X',
+        or None if the input was None.
+    """
     if text is None:
-        return None
+        return ""
     return "".join(ch if ch.isspace() else "X" for ch in text)
 
 
-def redact_values(diagram, map_file_path):
+def redact_values(diagram: ParsedDiagram, map_file_path: Path) -> ParsedDiagram:
+    """
+    Redact all textual values in a diagram.
+
+    Original values are stored in a JSON file, keyed by element ID, so they
+    can later be restored.
+
+    Args:
+        diagram: A diagram instance containing shapes and edges.
+        map_file_path: File path where the ID-to-original-value mapping
+            will be written as JSON.
+
+    Returns:
+        The modified diagram with all applicable text fields redacted.
+    """
     id_value_map: dict[str, str] = {}
 
     for node in diagram.shapes + diagram.edges:
@@ -18,13 +45,13 @@ def redact_values(diagram, map_file_path):
             if node.value is None:
                 continue
             id_value_map[node.id] = node.value
-            node.value = redact_text(node.value)
+            node.value = _redact_text(node.value)
 
         elif isinstance(node, Edge):
             if node.label is None:
                 continue
             id_value_map[node.id] = node.label
-            node.label = redact_text(node.label)
+            node.label = _redact_text(node.label)
 
     with open(map_file_path, "w", encoding="utf-8") as f:
         json.dump(
@@ -39,7 +66,17 @@ def redact_values(diagram, map_file_path):
     return diagram
 
 
-def restore_values(diagram, map_file_path: Path):
+def restore_values(diagram: ParsedDiagram, map_file_path: Path) -> ParsedDiagram:
+    """
+    Restore redacted diagram values from a JSON mapping file.
+
+    Args:
+        diagram: A diagram instance containing shapes and edges.
+        map_file_path: Path to the JSON file created by `redact_values`.
+
+    Returns:
+        The modified diagram with restored text values.
+    """
     if not map_file_path.exists():
         raise FileNotFoundError(f"Restore map not found: {map_file_path}")
 

--- a/src/drawpyo/utils/standard_colors.py
+++ b/src/drawpyo/utils/standard_colors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 
 

--- a/src/drawpyo/xml_base.py
+++ b/src/drawpyo/xml_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, Optional, Any, Union
 
 xmlize: Dict[str, str] = {}


### PR DESCRIPTION
This PR introduces reversible redaction for diagram labels to support secure external sharing.

## Changes

- Redacts object and edge labels in diagrams and stores their original values in a JSON mapping file
- Restores original label contents using the saved mapping
- Enables removal of confidential information before sharing diagrams with third parties for visual or layout adjustments

## PR roadmap:
- Reaction logic and saving map ✅
- Restore logic from loaded map ✅
- Unit test
- Documentation