### PR TITLE
Extend tree diagram with edge labels

### DIFF
--- a/src/drawpyo/diagram_types/tree.py
+++ b/src/drawpyo/diagram_types/tree.py
@@ -564,7 +564,9 @@ class TreeDiagram:
             if len(actual_children) > 0:
                 # has children, go through each child and check its children
                 for child in actual_children:
-                    self.connect(tree_parent, child)
+                    self.connect(
+                        source=tree_parent, target=child, label=child.parent_edge_label
+                    )
                     child_actual_children = [
                         c for c in child.tree_children if c is not None
                     ]

--- a/src/drawpyo/diagram_types/tree.py
+++ b/src/drawpyo/diagram_types/tree.py
@@ -20,7 +20,7 @@ class NodeObject(Object):
 
         Keyword Args:
             tree_children (list, optional): A list of other NodeObjects
-            parent (list, optional): The parent NodeObject
+            parent (NodeObject, optional): The parent NodeObject
             parent_edge_label (str, optional): The label for the edge drawn to the parent
         """
         super().__init__(**kwargs)

--- a/src/drawpyo/diagram_types/tree.py
+++ b/src/drawpyo/diagram_types/tree.py
@@ -21,11 +21,13 @@ class NodeObject(Object):
         Keyword Args:
             tree_children (list, optional): A list of other NodeObjects
             parent (list, optional): The parent NodeObject
+            parent_edge_label (str, optional): The label for the edge drawn to the parent
         """
         super().__init__(**kwargs)
         self.tree: Optional[TreeDiagram] = tree
         self.tree_children: List[NodeObject] = kwargs.get("tree_children", [])
         self.tree_parent: Optional[NodeObject] = kwargs.get("tree_parent", None)
+        self.parent_edge_label: Optional[str] = kwargs.get("parent_edge_label", None)
         self.peers: List[NodeObject] = []
         # self.level = kwargs.get("level", None)
         # self.peers = kwargs.get("peers", [])
@@ -647,8 +649,10 @@ class TreeDiagram:
                     edge.apply_attribute_dict(peer_style)
                     self.links.append(edge)
 
-    def connect(self, source: NodeObject, target: NodeObject) -> None:
-        edge = Edge(page=self.page, source=source, target=target)
+    def connect(
+        self, source: NodeObject, target: NodeObject, label: Optional[str] = None
+    ) -> None:
+        edge = Edge(page=self.page, source=source, target=target, label=label)
         edge.apply_attribute_dict(self.link_style_dict)
         if self.direction == "down":
             # parent style
@@ -685,7 +689,9 @@ class TreeDiagram:
         for lvl in self.objects.values():
             for obj in lvl:
                 if obj.tree_parent is not None:
-                    self.connect(source=obj.tree_parent, target=obj)
+                    self.connect(
+                        source=obj.tree_parent, target=obj, label=obj.parent_edge_label
+                    )
 
     def write(self, **kwargs) -> None:
         self.file.write(**kwargs)


### PR DESCRIPTION
Might fix #117

There seems to be no tests for TreeDiagram itself, so I don't know where to start for ensuring test coverage. Normally I would've tweaked an existing testcase so that an edge is added with and another one without.

I also don't see a clear way how to communicate this added feature to the documentation.

I don't see it as a problem that the edge labels are not supported when generating from a dictionary.
