### PR TITLE
Add support for changing a Page's name after creation

### DIFF
--- a/src/drawpyo/page.py
+++ b/src/drawpyo/page.py
@@ -47,13 +47,6 @@ class Page:
 
         # Properties
 
-        if self.file is not None:
-            page_num = len(self.file.pages)
-        else:
-            page_num = 1
-        self.name: str = kwargs.get("name", f"Page-{page_num}")
-        self.page_num: int = kwargs.get("page_num", page_num)
-
         self.dx: Union[int, float] = kwargs.get("dx", 2037)
         self.dy: Union[int, float] = kwargs.get("dy", 830)
         self.grid: int = kwargs.get("grid", 1)
@@ -80,9 +73,16 @@ class Page:
 
         # In the Draw.io file format, each page is actually three nested XML
         # tags. These are defined as XMLBase subclasses below
-        self.diagram: Diagram = Diagram(name=self.name)
+        self.diagram: Diagram = Diagram()
         self.mxGraph: mxGraph = mxGraph(page=self)
         self.root: Root = Root()
+
+        if self.file is not None:
+            page_num = len(self.file.pages)
+        else:
+            page_num = 1
+        self.name: str = kwargs.get("name", f"Page-{page_num}")
+        self.page_num: int = kwargs.get("page_num", page_num)
 
         logger.info(f"📄 Page created: '{self.__repr__()}'")
 
@@ -101,6 +101,14 @@ class Page:
 
     def remove_object(self, obj: Any) -> None:
         self.objects.remove(obj)
+
+    @property
+    def name(self) -> str:
+        return self.diagram.name
+
+    @name.setter
+    def name(self, n: str) -> None:
+        self.diagram.name = n
 
     @property
     def file(self) -> Optional[Any]:

--- a/tests/page_test.py
+++ b/tests/page_test.py
@@ -68,6 +68,13 @@ class TestPageInit:
         page = drawpyo.Page(name="Custom Page")
         assert page.name == "Custom Page"
 
+    def test_with_name_changed(self) -> None:
+        """Checks if a page reflects a name change into its Diagram"""
+        page = drawpyo.Page(name="Initial Page")
+        page.name = "Custom Page"
+        assert page.name == "Custom Page"
+        assert page.diagram.name == "Custom Page"
+
     def test_with_file_reference(self, empty_file: drawpyo.File) -> None:
         """Checks if a page is created with a file link"""
         page = drawpyo.Page(file=empty_file)


### PR DESCRIPTION
Should fix #132 

Initially I had a simpler fix but this reflects the structure I saw in TreeDiagram where you use the property.setter definition instead of duplicating that knowledge in the init function. Hence moving the code.